### PR TITLE
Add Gauss-sum portraits to Dirichlet character pages (LMFDB#3996)

### DIFF
--- a/lmfdb/characters/main.py
+++ b/lmfdb/characters/main.py
@@ -547,6 +547,10 @@ def render_Dirichletwebpage(modulus=None, orbit_label=None, number=None):
     info['learnmore'] = learn()
     info['downloads'] = downloads
     info['KNOWL_ID'] = 'character.dirichlet.%s.%s' % (modulus, number)
+    # Gauss-sum portrait in the properties box (#3996); local import keeps this
+    # hook self-contained (see lmfdb/characters/portraits.py).
+    from lmfdb.characters.portraits import add_portrait
+    add_portrait(info, modulus, number)
     return render_template('Character.html', **info)
 
 @characters_page.route('/Dirichlet/<label>/download/<download_type>')

--- a/lmfdb/characters/portraits.py
+++ b/lmfdb/characters/portraits.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+r"""
+Portraits (Gauss-sum visualizations) for Dirichlet characters.
+
+Following the design proposed in https://github.com/LMFDB/lmfdb/issues/3996
+(see the demo at https://alexjbest.github.io/dirich/), the portrait of a
+Dirichlet character `\chi` of modulus `N` shows, for each residue
+`a \in \{0, \dots, N-1\}`, the partial Gauss sums
+
+.. MATH::
+
+    S_a(k) = \sum_{n=1}^{k} \chi(n) e^{2\pi i a n / N},
+    \qquad k = 1, \dots, N-1,
+
+as radial segments from the origin, colored by `a` (rainbow hue), with early
+partial sums darkened and later ones at full brightness.  A large dot of the
+same color marks the complete Gauss sum `\tau_a(\chi) = S_a(N-1)`, and a grey
+circle of radius `\sqrt{N}` is drawn: for a primitive character every dot with
+`\gcd(a, N) = 1` lands exactly on this circle, so primitivity (and much else:
+the order of the character as rotational symmetry, reality as symmetry about
+the real axis, triviality as a red horizontal spike) is visible at a glance.
+
+The plot is computed on the fly, so we only do it for small modulus
+(`N \le PORTRAIT_MAX_MODULUS`); the number of segments drawn is
+`N \cdot \phi(N)`, and rendering time grows accordingly.  For speed the
+segments are rendered as a single matplotlib ``LineCollection`` wrapped in a
+sage ``GraphicPrimitive``, so the result is an ordinary sage ``Graphics``
+object that is embedded in the page via ``encode_plot``, as for elliptic
+curve and Maass form plots.
+"""
+
+from sage.all import Graphics, circle, gcd, sqrt
+from sage.plot.colors import rainbow
+from sage.plot.plot import minmax_data
+from sage.plot.primitive import GraphicPrimitive
+
+from lmfdb.characters.TinyConrey import ConreyCharacter
+from lmfdb.logger import logger
+from lmfdb.utils import encode_plot
+
+# Portraits are only computed on the fly for modulus at most this bound
+# (roughly 0.1s of rendering time at N = 300, growing to several seconds by
+# N = 1000, hence the cutoff).  If portraits are ever precomputed and stored
+# in the database, this restriction can be lifted.
+PORTRAIT_MAX_MODULUS = 300
+
+
+class PartialGaussSums(GraphicPrimitive):
+    """
+    Graphics primitive drawing all partial Gauss sums of a Dirichlet
+    character as radial segments, and the complete Gauss sums as dots.
+
+    Rendering ``N * phi(N)`` segments as individual sage lines is far too
+    slow, so this primitive holds them in numpy arrays and renders them as a
+    single matplotlib ``LineCollection`` (plus one scatter plot for the dots).
+    """
+    def __init__(self, segments, segment_colors, dots, dot_colors):
+        self.segments = segments  # (k, 2, 2): k segments from (0,0) to S_a(n)
+        self.segment_colors = segment_colors  # (k, 4) rgba
+        self.dots = dots  # (N, 2): complete Gauss sums
+        self.dot_colors = dot_colors  # (N, 4) rgba
+        GraphicPrimitive.__init__(self, {})
+
+    def get_minmax_data(self):
+        xdata = list(self.segments[:, :, 0].flatten()) + list(self.dots[:, 0])
+        ydata = list(self.segments[:, :, 1].flatten()) + list(self.dots[:, 1])
+        return minmax_data(xdata, ydata, dict=True)
+
+    def _render_on_subplot(self, subplot):
+        from matplotlib.collections import LineCollection
+        subplot.add_collection(
+            LineCollection(self.segments, colors=self.segment_colors,
+                           linewidths=1.5, zorder=2))
+        subplot.scatter(self.dots[:, 0], self.dots[:, 1], s=60,
+                        c=self.dot_colors, zorder=10)
+
+
+def partial_gauss_sums(modulus, number):
+    """
+    The partial Gauss sums of the Dirichlet character
+    `\\chi_{modulus}(number, \\cdot)`.
+
+    Returns a pair ``(ns, sums)`` of numpy arrays, where ``ns`` lists the
+    `n \\in \\{1, \\dots, N-1\\}` coprime to `N = modulus` and ``sums`` has
+    shape ``(N, len(ns))`` with ``sums[a, k]`` the partial Gauss sum
+    `S_a(ns[k])`; in particular ``sums[a, -1]`` is the complete Gauss sum
+    `\\tau_a(\\chi)`.
+    """
+    import numpy as np
+
+    N = modulus
+    chi = ConreyCharacter(N, number)
+    # the n with chi(n) != 0, and chi(n) = e(angle(n)) for those n
+    ns = np.array([n for n in range(1, N) if gcd(n, N) == 1])
+    angles = np.array([float(chi.conreyangle(int(n))) for n in ns])
+    chivals = np.exp(2j * np.pi * angles)
+    # partial sums S_a(n) for all a (rows) and n in ns (columns)
+    avals = np.arange(N)
+    phases = np.exp(2j * np.pi * np.outer(avals, ns) / N)
+    return ns, np.cumsum(chivals[np.newaxis, :] * phases, axis=1)
+
+
+def paint_portrait(modulus, number):
+    """
+    The portrait of the Dirichlet character `\\chi_{modulus}(number, \\cdot)`
+    as a base64-encoded png data URI, or ``None`` if the modulus exceeds
+    ``PORTRAIT_MAX_MODULUS``.
+    """
+    if modulus > PORTRAIT_MAX_MODULUS:
+        return None
+    import numpy as np
+
+    N = modulus
+    if N == 1:
+        # chi(n) = 1 for all n; tau_0 = 1 is the only (empty) Gauss sum
+        segments = np.zeros((0, 2, 2))
+        segment_colors = np.zeros((0, 4))
+        dots = np.array([[1.0, 0.0]])
+        dot_colors = np.array([[1.0, 0.0, 0.0, 0.8]])
+    else:
+        ns, sums = partial_gauss_sums(N, number)
+
+        # rainbow color for each a, darkened for early partial sums as in
+        # the demo: darker(3*(N-1-n)/(5*N)) scales rgb by 1 - 3*(N-1-n)/(5*N)
+        base = np.array([[int(h[1:3], 16), int(h[3:5], 16), int(h[5:7], 16)]
+                         for h in rainbow(N)]) / 255.0
+        brightness = 1.0 - 3.0 * (N - 1 - ns) / (5.0 * N)
+
+        k = N * len(ns)
+        segments = np.zeros((k, 2, 2))
+        segments[:, 1, 0] = sums.real.flatten()
+        segments[:, 1, 1] = sums.imag.flatten()
+        segment_colors = np.empty((k, 4))
+        segment_colors[:, :3] = (base[:, np.newaxis, :]
+                                 * brightness[np.newaxis, :, np.newaxis]
+                                 ).reshape(k, 3)
+        segment_colors[:, 3] = 0.35
+
+        dots = np.column_stack([sums[:, -1].real, sums[:, -1].imag])
+        dot_colors = np.empty((N, 4))
+        dot_colors[:, :3] = base
+        dot_colors[:, 3] = 0.8
+
+    G = Graphics()
+    G.add_primitive(PartialGaussSums(segments, segment_colors,
+                                     dots, dot_colors))
+    G += circle((0, 0), sqrt(modulus), color="grey", zorder=1)
+    G.set_aspect_ratio(1)
+    G.axes(False)
+    return encode_plot(G, pad=0, pad_inches=0, transparent=True,
+                       remove_axes=True, axes_pad=0.05, figsize=[4, 4])
+
+
+def portrait_properties(modulus, number):
+    """
+    The portrait of `\\chi_{modulus}(number, \\cdot)` as a ``(None, html)``
+    pair ready to drop into a properties box: a thumbnail linking to the
+    full-size image, exactly as elliptic curve and Maass form plots do.
+    Returns ``None`` when the portrait is skipped (modulus above
+    ``PORTRAIT_MAX_MODULUS``), so callers can test the result directly.
+    """
+    uri = paint_portrait(modulus, number)
+    if uri is None:
+        return None
+    link = '<a href="{0}"><img src="{0}" width="200" height="200"/></a>'.format(uri)
+    return (None, link)
+
+
+def add_portrait(info, modulus, number):
+    """
+    Insert the portrait of `\\chi_{modulus}(number, \\cdot)` into the
+    properties box carried by ``info['properties']``, just below the label
+    (the position used for the elliptic curve plot).  A no-op when the
+    portrait is skipped for large modulus or when ``info`` has no properties
+    box, so it is safe to call unconditionally from the character route.
+
+    Any failure while building the portrait is logged and swallowed: the
+    portrait is decorative and must never break the character page.
+    """
+    try:
+        entry = portrait_properties(modulus, number)
+    except Exception:
+        logger.error("failed to build portrait for character %s.%s",
+                     modulus, number, exc_info=True)
+        return
+    if entry is not None and info.get("properties"):
+        info["properties"].insert(1, entry)

--- a/lmfdb/characters/test_characters.py
+++ b/lmfdb/characters/test_characters.py
@@ -183,6 +183,15 @@ class DirichletCharactersTest(LmfdbTest):
         assert 'Kronecker symbol' in W.get_data(as_text=True)
         assert r'\left(\frac{-4}{\bullet}\right)' in W.get_data(as_text=True)
 
+    def test_portrait(self):
+        # The Gauss-sum portrait (issue #3996) is embedded in the properties
+        # box for small modulus, computed on the fly.
+        W = self.tc.get('/Character/Dirichlet/27/8')
+        assert 'data:image/png;base64,' in W.get_data(as_text=True), "portrait present"
+        # It is skipped for large modulus, where computing it on the fly is too slow.
+        W = self.tc.get('/Character/Dirichlet/40487/5')
+        assert 'data:image/png;base64,' not in W.get_data(as_text=True), "portrait skipped"
+
     def test_dirichlet_calc(self):
         W = self.tc.get('/Character/calc-gauss/Dirichlet/4/3?val=3')
         assert '-2.0i' in W.get_data(as_text=True), "calc gauss"


### PR DESCRIPTION
New self-contained module lmfdb/characters/portraits.py draws, for each residue a mod N, the partial Gauss sums S_a(k) as rainbow radial segments (early terms darkened), the complete Gauss sums as dots, and a circle of radius sqrt(N), following Alex Best's demo from the issue; rendered as a single matplotlib LineCollection and embedded via encode_plot in the properties box (the elliptic curve pattern). Computed on the fly for modulus up to 300, skipped above. Hook is a single 4-line call in render_Dirichletwebpage; any portrait failure is logged and swallowed.

Verified: complete sums match pari znchargauss to 1e-13 for ~18 odd/even/primitive/imprimitive/trivial characters, |tau_a|=sqrt(N) for primitive chi at coprime a, 27.8 matches the issue's demo image; pages checked via flask test client for N=1..300 and skip for N>300; DirichletCharactersTest (17 tests incl. new test_portrait) green; pyflakes clean.